### PR TITLE
Refactor configuration options to remove templated generics.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -91,6 +91,7 @@ linters:
             max-distance: 10
             ignore-decls:
                 - c *Config[T]
+                - c configurable
 
         whitespace:
             multi-if: true

--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ type Config struct {
 // main will read and display the configuration
 func main() {
 	c, confErr := templig.New[Config](
-		templig.WithFile[Config]("my_config.yaml"),
-		templig.WithValue[Config]("pass", "secret"))
+		templig.WithFile("my_config.yaml"),
+		templig.WithValue("pass", "secret"))
   
 	fmt.Printf("read errors: %v", confErr)
 

--- a/config.go
+++ b/config.go
@@ -66,71 +66,91 @@ type Config[T any] struct {
 	values   map[string]any
 }
 
+type configurable interface {
+	SetSecretRE(newSecretRE *regexp.Regexp) error
+	addSources(sources ...source) error
+	addValue(key string, val any) error
+}
+
 // Option defines a functional option for configuring a Config instance.
 // It applies modifications or settings to the Config.
-type Option[T any] func(*Config[T]) error
+type Option func(configurable) error
 
 // WithSecretRE returns an Option to set the regular expression used for hiding secrets in the configuration.
-func WithSecretRE[T any](re *regexp.Regexp) Option[T] {
-	return func(c *Config[T]) error {
+func WithSecretRE(re *regexp.Regexp) Option {
+	return func(c configurable) error {
 		return c.SetSecretRE(re)
 	}
 }
 
+func (c *Config[T]) addSources(sources ...source) error {
+	if len(sources) == 0 {
+		return errors.Join(ErrNoConfigPaths, ErrNoConfigReaders)
+	}
+
+	newSources := make([]source, len(c.sources)+len(sources))
+
+	copy(newSources, c.sources)
+
+	for i, j := len(c.sources), 0; j < len(sources); i, j = i+1, j+1 {
+		newSources[i] = sources[j]
+	}
+
+	c.sources = newSources
+
+	return nil
+}
+
 // WithFile creates an Option to specify file paths as configuration sources for the Config instance.
-func WithFile[T any](fileNames ...string) Option[T] {
-	return func(c *Config[T]) error {
+func WithFile(fileNames ...string) Option {
+	return func(c configurable) error {
 		if len(fileNames) == 0 {
 			return ErrNoConfigPaths
 		}
 
-		sources := make([]source, len(c.sources)+len(fileNames))
+		sources := make([]source, len(fileNames))
 
-		copy(sources, c.sources)
-
-		for i, j := len(c.sources), 0; j < len(fileNames); i, j = i+1, j+1 {
-			sources[i] = source{fileName: fileNames[j]}
+		for i := range fileNames {
+			sources[i] = source{fileName: fileNames[i]}
 		}
 
-		c.sources = sources
-
-		return nil
+		return c.addSources(sources...)
 	}
 }
 
 // WithReader creates an Option that adds the provided io.Reader instances as configuration sources.
-func WithReader[T any](readers ...io.Reader) Option[T] {
-	return func(c *Config[T]) error {
+func WithReader(readers ...io.Reader) Option {
+	return func(c configurable) error {
 		if len(readers) == 0 {
 			return ErrNoConfigReaders
 		}
 
-		sources := make([]source, len(c.sources)+len(readers))
+		sources := make([]source, len(readers))
 
-		copy(sources, c.sources)
-
-		for i, j := len(c.sources), 0; j < len(readers); i, j = i+1, j+1 {
-			sources[i] = source{reader: readers[j]}
+		for i := range readers {
+			sources[i] = source{reader: readers[i]}
 		}
 
-		c.sources = sources
-
-		return nil
+		return c.addSources(sources...)
 	}
 }
 
-// WithValue creates an Option that sets a key-value pair in the configuration's values map.
-func WithValue[T any](k string, v any) Option[T] {
-	return func(c *Config[T]) error {
-		c.values[k] = v
+func (c *Config[T]) addValue(key string, value any) error {
+	c.values[key] = value
 
-		return nil
+	return nil
+}
+
+// WithValue creates an Option that sets a key-value pair in the configuration's values map.
+func WithValue(key string, value any) Option {
+	return func(c configurable) error {
+		return c.addValue(key, value)
 	}
 }
 
 // New creates a new Config instance of type T using the provided options and
 // returns it along with any errors encountered.
-func New[T any](opts ...Option[T]) (*Config[T], error) {
+func New[T any](opts ...Option) (*Config[T], error) {
 	c := new(Config[T])
 	c.values = make(map[string]any)
 
@@ -256,11 +276,11 @@ func (c *Config[T]) fromSingle(r io.Reader) error {
 // overlay is called repeatedly and overlays the current intermediate configuration
 // with the content of the given io.Reader.
 func (c *Config[T]) overlay(r io.Reader) error {
-	opts := make([]Option[yaml.Node], 0, len(c.values)+1)
-	opts = append(opts, WithReader[yaml.Node](r))
+	opts := make([]Option, 0, len(c.values)+1)
+	opts = append(opts, WithReader(r))
 
 	for k, v := range c.values {
-		opts = append(opts, WithValue[yaml.Node](k, v))
+		opts = append(opts, WithValue(k, v))
 	}
 
 	additionalConfig, aErr := New[yaml.Node](opts...)
@@ -413,13 +433,13 @@ func (c *Config[T]) SetSecretRE(re *regexp.Regexp) error {
 
 // From is a convenience wrapper that reads a configuration from the given set of io.Reader.
 func From[T any](readers ...io.Reader) (*Config[T], error) {
-	return New[T](WithReader[T](readers...))
+	return New[T](WithReader(readers...))
 }
 
 // FromFile is a convenience wrapper that loads a series of configuration files. The first file is considered the base,
 // all others are loaded on top of that one using the [MergeYAMLNodes] functionality.
 func FromFile[T any](paths ...string) (*Config[T], error) {
-	return New[T](WithFile[T](paths...))
+	return New[T](WithFile(paths...))
 }
 
 // FromFiles is a convenience wrapper that loads a series of configuration files. The first file is considered the base,

--- a/config.go
+++ b/config.go
@@ -66,6 +66,9 @@ type Config[T any] struct {
 	values   map[string]any
 }
 
+// configurable defines an interface for managing configuration sources, adding key-value pairs,
+// and setting secret patterns. It is used to conveniently configure the Config structure as directly operating
+// on it would cause all functional options to be amended with the generic type.
 type configurable interface {
 	SetSecretRE(newSecretRE *regexp.Regexp) error
 	addSources(sources ...source) error

--- a/config_internal_test.go
+++ b/config_internal_test.go
@@ -19,3 +19,13 @@ func TestEmptySource0(t *testing.T) {
 		t.Errorf("reading from empty source should have returned an error")
 	}
 }
+
+func TestNoSources(t *testing.T) {
+	t.Parallel()
+
+	c := Config[int]{}
+
+	if err := c.addSources(); !errors.Is(err, ErrNoConfigPaths) || !errors.Is(err, ErrNoConfigReaders) {
+		t.Errorf("adding no sources should have returned an error")
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -317,10 +317,10 @@ func TestReadConfig(t *testing.T) {
 				os.Args = append(os.Args, test.args...)
 			}
 
-			options := []templig.Option[TestConfig]{}
+			var options []templig.Option
 
 			for k, v := range test.values {
-				options = append(options, templig.WithValue[TestConfig](k, v))
+				options = append(options, templig.WithValue(k, v))
 			}
 
 			var config *templig.Config[TestConfig]
@@ -328,16 +328,16 @@ func TestReadConfig(t *testing.T) {
 
 			switch {
 			case len(test.in) > 0:
-				options = append(options, templig.WithReader[TestConfig](&testBuf))
+				options = append(options, templig.WithReader(&testBuf))
 			case len(test.inFile) > 0:
-				options = append(options, templig.WithFile[TestConfig](test.inFile))
+				options = append(options, templig.WithFile(test.inFile))
 			default:
 				t.Errorf("%v: neither input data nor input file given", testIndex)
 			}
 
 			config, fromErr = templig.New[TestConfig](options...)
 
-			if !test.wantErr && config.SecretRE() == nil {
+			if !test.wantErr && (config == nil || config.SecretRE() == nil) {
 				t.Errorf("%v: wanted SecretRE to be initialized", testIndex)
 			}
 
@@ -418,9 +418,9 @@ func TestReadOverlayConfig(t *testing.T) {
 	t.Parallel()
 
 	config, configErr := templig.New[TestConfig](
-		templig.WithValue[TestConfig]("pass2", "pass2"),
-		templig.WithFile[TestConfig]("testData/test_config_0.yaml"),
-		templig.WithFile[TestConfig]("testData/test_config_0_overlay.yaml"))
+		templig.WithValue("pass2", "pass2"),
+		templig.WithFile("testData/test_config_0.yaml"),
+		templig.WithFile("testData/test_config_0_overlay.yaml"))
 
 	if configErr != nil {
 		t.Errorf("no error expected reading multiple files: %v", configErr)
@@ -446,8 +446,8 @@ func TestReadOverlayConfigReader(t *testing.T) {
 	f1, _ := os.Open("testData/test_config_0_overlay.yaml")
 
 	config, configErr := templig.New[TestConfig](
-		templig.WithValue[TestConfig]("pass2", "pass2"),
-		templig.WithReader[TestConfig](f0, f1))
+		templig.WithValue("pass2", "pass2"),
+		templig.WithReader(f0, f1))
 
 	if configErr != nil {
 		t.Errorf("no error expected reading multiple files: %v", configErr)
@@ -859,8 +859,8 @@ func TestSetSecretRENil(t *testing.T) {
 	t.Parallel()
 
 	_, err := templig.New[TestConfig](
-		templig.WithFile[TestConfig]("testData/test_config_0.yaml"),
-		templig.WithSecretRE[TestConfig](nil))
+		templig.WithFile("testData/test_config_0.yaml"),
+		templig.WithSecretRE(nil))
 
 	if !errors.Is(err, templig.ErrNoSecretRegexp) {
 		t.Errorf("setting secret regex to nil should return an error")

--- a/examples/templating/value/main.go
+++ b/examples/templating/value/main.go
@@ -25,8 +25,8 @@ type Config struct {
 // To insert a custom variable into the configuration, the WithValue option is used.
 func main() {
 	cfg, confErr := templig.New[Config](
-		templig.WithFile[Config]("my_config.yaml"),
-		templig.WithValue[Config]("pass", "secret"))
+		templig.WithFile("my_config.yaml"),
+		templig.WithValue("pass", "secret"))
 
 	fmt.Printf("read errors: %v\n", confErr)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration options now work without requiring explicit type parameters in examples and usage, making setup simpler.

* **Bug Fixes**
  * Improved handling for configurations with no available sources, with clearer error coverage.

* **Documentation**
  * Updated the custom values example to match the newer option syntax.

* **Tests**
  * Expanded test coverage for missing configuration sources and updated existing tests to reflect the new option style.

* **Chores**
  * Adjusted lint settings to account for the updated implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->